### PR TITLE
Disable LDAP cache

### DIFF
--- a/confluence/site/classes/atlassian-user.xml
+++ b/confluence/site/classes/atlassian-user.xml
@@ -17,7 +17,7 @@
 
              http://confluence.atlassian.com/display/DOC/Customising+atlassian-user.xml
         -->
-      <ldap key="ldapRepository" name="LDAP Repository@hecate.atlassian.com" cache="true">
+      <ldap key="ldapRepository" name="LDAP Repository@hecate.atlassian.com" cache="false">
         <host>ldap.jenkins-ci.org</host>
         <port>636</port>
         <securityPrincipal>cn=admin,dc=jenkins-ci,dc=org</securityPrincipal>


### PR DESCRIPTION
One of the problems we found while fighting the spam is that even when
deleting an user from LDAP, the user in question can continue to spam
Wiki.

I think disabling LDAP cache in Confluence might solve this. At the same
time, this might have some unknown performance implication.

More information about this is in
https://confluence.atlassian.com/bamboo/configuring-the-caching-of-your-ldap-repository-289277216.html
