### PR TITLE
Kill the Confluence JVM when we hit an OutOfMemoryError

### DIFF
--- a/confluence/site/bin/setenv.sh
+++ b/confluence/site/bin/setenv.sh
@@ -3,4 +3,4 @@
 # read the one shipped by Atlassian first
 . /srv/wiki/base/bin/setenv.sh
 
-export JAVA_OPTS="$JAVA_OPTS -Djava.awt.headless=true -Xms512m -Xmx1024m -XX:MaxPermSize=256m"
+export JAVA_OPTS="${JAVA_OPTS} -Djava.awt.headless=true -Xms512m -Xmx1024m -XX:MaxPermSize=256m -XX:+HeapDumpOnOutOfMemoryError -XX:OnOutOfMemoryError=\"kill -9 %p\""


### PR DESCRIPTION
These are effectively unrecoverable and if the JVM doesn't die, then we risk
having a _functional_ docker container but a JVM which isn't responding to
requests.

This in essence should ensure that the container crashes and hopefully upstart
restarts us

Fixes [INFRA-383](https://issues.jenkins-ci.org/browse/INFRA-383)
