### PR TITLE
Revert "Disable LDAP cache."

### DIFF
--- a/confluence/site/classes/atlassian-user.xml
+++ b/confluence/site/classes/atlassian-user.xml
@@ -17,7 +17,7 @@
 
              http://confluence.atlassian.com/display/DOC/Customising+atlassian-user.xml
         -->
-      <ldap key="ldapRepository" name="LDAP Repository@hecate.atlassian.com" cache="false">
+      <ldap key="ldapRepository" name="LDAP Repository@hecate.atlassian.com" cache="true">
         <host>ldap.jenkins-ci.org</host>
         <port>636</port>
         <securityPrincipal>cn=admin,dc=jenkins-ci,dc=org</securityPrincipal>


### PR DESCRIPTION
This reverts commit 55c6b3c8b4e837435b541051290590225da4de6e.

I'm hazarding a guess that this change, which wasn't properly deployed until
recently is the cause of Confluence blocking indefinitely right now:

```
root@lettuce:/var/log/upstart# ps auxww | grep java
wiki      5274 21.1 12.7 2574632 1039912 ?     Sl   18:46  12:00 /usr/bin/java -Dnop -Xms256m -Xmx512m -XX:MaxPermSize=256m -Djava.awt.headless=true -Djava.awt.headless=true -Xms512m -Xmx1024m -XX:MaxPermSize=256m -XX:OnOutOfMemoryError=/srv/wiki/site/bin/oomkill -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager -Djava.endorsed.dirs=/srv/wiki/base/endorsed -classpath /srv/wiki/base/bin/bootstrap.jar -Dcatalina.base=/srv/wiki/site -Dcatalina.home=/srv/wiki/base -Djava.io.tmpdir=/srv/wiki/site/temp org.apache.catalina.startup.Bootstrap start
root     10709  0.0  0.0   9388   900 pts/5    S+   19:42   0:00 grep --color=auto java
root@lettuce:/var/log/upstart# strace -p 5274
Process 5274 attached - interrupt to quit
futex(0x7f92c1fe29d0, FUTEX_WAIT, 99, NULL^C <unfinished ...>
Process 5274 detached
root@lettuce:/var/log/upstart#
```
