### PR TITLE
[INFRA-1150][INFRA-1149][INFRA-1201] Update confluence to 5.9.14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ startdb:
 		-e MYSQL_USER=wiki \
 		-e MYSQL_PASSWORD=kiwi \
 		-e MYSQL_DATABASE=wikidb \
-		mariadb --character-set-server=utf8 --default-storage-engine=innodb
-    
+		mariadb --character-set-server=utf8 --default-storage-engine=innodb --innodb-log-file-size=536870916
+
 restoredb:
 	# restore dump from DB
 	gunzip -c backup.db.gz | docker exec -i wiki-db mysql --user=wiki --password=kiwi wikidb

--- a/README.md
+++ b/README.md
@@ -76,16 +76,21 @@ you can use the same evaluation license over and over.
 ## TODO
 * oom_adj
 
-## Connection to mock_ldap need to be done on ldap port 389 instead of ldap
+## Mock Ldap
+Connection to mock_ldap need to be done on ldap port 389 instead of ldap
 Change ldaps:// to ldap:// in `confluence/site/conf/server.xml`
 Change Port 636 to 389 in confluence/site/classes/atlassian-user.xml
 
 ## UTF8
-Confluence will not start anymore if it detects non utf8 tables.
-The list of database modification that need to be applied can be retrieved with following script 'scripts/utf8_encoding.sql'.
+Confluence will not start anymore if it detects non utf8 tables.  
+The list of database modification that need to be applied can be retrieved with following script 'scripts/utf8_encoding.sql'.  
 You then need to apply them.
 
-  mysql -h localhost -u wiki -p kiwi wikidb < scripts/utf8_encoding.sql > scripts/to_update.sql
-  sed -i '/CONCAT/d' scripts/to_update.sql
-  mysql -h localhost -u wiki -p kiwi wikidb < scripts/to_update.sql
-
+```
+## Generate sql migration script
+mysql -h localhost -u wiki -p kiwi wikidb < scripts/utf8_encoding.sql > scripts/to_update.sql
+## Remove CONCAT entry from migration script
+sed -i '/CONCAT/d' scripts/to_update.sql
+## Apply migration
+mysql -h localhost -u wiki -p kiwi wikidb < scripts/to_update.sql
+```

--- a/README.md
+++ b/README.md
@@ -75,3 +75,7 @@ you can use the same evaluation license over and over.
 
 ## TODO
 * oom_adj
+
+## Connection to mock_ldap need to be done on ldap port 389 instead of ldap
+Change ldaps:// to ldap:// in `confluence/site/conf/server.xml`
+Change Port 636 to 389 in confluence/site/classes/atlassian-user.xml

--- a/README.md
+++ b/README.md
@@ -79,3 +79,13 @@ you can use the same evaluation license over and over.
 ## Connection to mock_ldap need to be done on ldap port 389 instead of ldap
 Change ldaps:// to ldap:// in `confluence/site/conf/server.xml`
 Change Port 636 to 389 in confluence/site/classes/atlassian-user.xml
+
+## UTF8
+Confluence will not start anymore if it detects non utf8 tables.
+The list of database modification that need to be applied can be retrieved with following script 'scripts/utf8_encoding.sql'.
+You then need to apply them.
+
+  mysql -h localhost -u wiki -p kiwi wikidb < scripts/utf8_encoding.sql > scripts/to_update.sql
+  sed -i '/CONCAT/d' scripts/to_update.sql
+  mysql -h localhost -u wiki -p kiwi wikidb < scripts/to_update.sql
+

--- a/UPGRADES.adoc
+++ b/UPGRADES.adoc
@@ -1,7 +1,31 @@
 = Upgrade Notes
 
+== 5.0.3 to 5.9.14
+* Usage of Jdbc resource
+* Upgrade from Openjdk 7 to Openjdk 8
+* Upgrade to Tomcat 8
+* Upgrade java heap size to 8Gb
+* Database must use utf8
+* Database upgrade very slow
 
-== 3,5.17 to 5.0.3
+----
+  # Generate mysql script to fix non utf8 table,columns
+  sudo -Hu wiki mysql --max_allowed_packet=256M hudson_confluence < scripts/utf8_encoding.sql > /tmp/fix_utf8_encoding.sql
+  # Remove 'CONCAT entry from /tmp/fix_utf8_encoding.sql'
+  sed -i '/CONCAT/d' /tmp/fix_utf8_encoding.sql
+  # Fix database for utf8
+  sudo -Hu wiki mysql --max_allowed_packet=256M hudson_confluence < /tmp/fix_utf8_encoding.sql
+  # Remove /tmp/fix_utf8_encoding.sql
+  rm /tmp/fix_utf8_encoding.sql
+----
+
+
+=== Issues encountered
+* Database must be fully encoded in utf8
+* link:https://confluence.atlassian.com/kb/how-to-fix-the-collation-and-character-set-of-a-mysql-database-744326173.html[Fix collation and character set of mysql]
+* link:https://confluence.atlassian.com/doc/configuring-database-character-encoding-177698.html[Configure database encoding]
+
+== 3.5.17 to 5.0.3
 
 * Upgraded from JDK6 to an `openjdk:7-jre` image since 5.x dropped support for JRE6
 * No notable database issues on migration, just lots of I/O saturation in the process

--- a/confluence/Dockerfile
+++ b/confluence/Dockerfile
@@ -3,8 +3,8 @@
 FROM openjdk:8-jre
 MAINTAINER Jenkins Infra team <infra@lists.jenkins-ci.org>
 
-ENV CONFLUENCE_VERSION 5.10.8
-ENV MYSQL_DRIVER mysql-connector-java-5.1.40
+ENV CONFLUENCE_VERSION 5.9.14
+ENV MYSQL_DRIVER mysql-connector-java-5.1.42
 
 # The compartmentalized URL that JIRA is going to be referenced as.
 ENV PROXY_SCHEME https

--- a/confluence/Dockerfile
+++ b/confluence/Dockerfile
@@ -4,6 +4,16 @@ FROM openjdk:8-jre
 MAINTAINER Jenkins Infra team <infra@lists.jenkins-ci.org>
 
 ENV CONFLUENCE_VERSION 5.10.8
+ENV MYSQL_DRIVER mysql-connector-java-5.1.40
+
+# The compartmentalized URL that JIRA is going to be referenced as.
+ENV PROXY_SCHEME https
+ENV PROXY_NAME wiki.jenkins-ci.org
+ENV PROXY_PORT 443
+
+# Password to LDAP server.
+ENV LDAP_PASSWORD password
+ENV LDAP_HOST ldap.jenkins.io
 
 RUN apt-get -q update && apt-get install -qy cron xmlstarlet curl
 
@@ -17,7 +27,6 @@ RUN curl -Lks https://www.atlassian.com/software/confluence/downloads/binary/atl
 RUN echo "confluence.home = /srv/wiki/home" > /srv/wiki/base/confluence/WEB-INF/classes/confluence-init.properties
 
 # Download and place MySQL driver
-ENV MYSQL_DRIVER=mysql-connector-java-5.1.40
 RUN curl -L http://dev.mysql.com/get/Downloads/Connector-J/${MYSQL_DRIVER}.tar.gz | tar zxv -C /tmp; \
     cp /tmp/${MYSQL_DRIVER}/${MYSQL_DRIVER}-bin.jar /srv/wiki/base/lib/${MYSQL_DRIVER}-bin.jar; \
     rm -rf /tmp/${MYSQL_DRIVER}
@@ -25,20 +34,11 @@ RUN curl -L http://dev.mysql.com/get/Downloads/Connector-J/${MYSQL_DRIVER}.tar.g
 # Allow the user to start cron
 RUN echo "wiki  ALL=(ALL) NOPASSWD: /usr/sbin/cron" >> /etc/sudoers
 
-# The compartmentalized URL that JIRA is going to be referenced as.
-ENV PROXY_SCHEME https
-ENV PROXY_NAME wiki.jenkins-ci.org
-ENV PROXY_PORT 443
-
-# Password to LDAP server.
-ENV LDAP_PASSWORD password
-ENV LDAP_HOST ldap.jenkins.io
 
 ADD launch.bash /launch
 ADD site /srv/wiki/site
 
 RUN chown -R wiki:wiki /srv/wiki
-
 
 WORKDIR /srv/wiki
 VOLUME ["/srv/wiki/home"]

--- a/confluence/site/bin/setenv.sh
+++ b/confluence/site/bin/setenv.sh
@@ -3,4 +3,4 @@
 # read the one shipped by Atlassian first
 . /srv/wiki/base/bin/setenv.sh
 set -x
-export JAVA_OPTS="$JAVA_OPTS -Djava.awt.headless=true -Xms512m -Xmx1024m -XX:MaxPermSize=256m -XX:OnOutOfMemoryError=/srv/wiki/site/bin/oomkill"
+export JAVA_OPTS="$JAVA_OPTS -Djava.awt.headless=true -Xms4096m -Xmx8192m -XX:MaxPermSize=256m -XX:OnOutOfMemoryError=/srv/wiki/site/bin/oomkill"

--- a/confluence/site/bin/setenv.sh
+++ b/confluence/site/bin/setenv.sh
@@ -1,6 +1,21 @@
 # sourced by catalina.sh upon start
 
-# read the one shipped by Atlassian first
-. /srv/wiki/base/bin/setenv.sh
+# Don't read the one shipped by Atlassian first
+#. /srv/wiki/base/bin/setenv.sh
+
 set -x
-export JAVA_OPTS="$JAVA_OPTS -Djava.awt.headless=true -Xms4096m -Xmx8192m -XX:MaxPermSize=256m -XX:OnOutOfMemoryError=/srv/wiki/site/bin/oomkill"
+
+CATALINA_OPTS="
+ -XX:-PrintGCDetails
+ -XX:+PrintGCTimeStamps
+ -XX:-PrintTenuringDistribution
+ -Xloggc:${HOME}/home/logs/gc-$(date +%F_%H-%M-%S).log
+ -XX:+UseGCLogFileRotation
+ -XX:NumberOfGCLogFiles=5
+ -XX:GCLogFileSize=2M
+ -Djava.awt.headless=true
+ -Datlassian.plugins.enable.wait=300
+ -Xms4096m -Xmx8192m -XX:+UseG1GC
+ -XX:OnOutOfMemoryError=/srv/wiki/site/bin/oomkill
+ ${CATALINA_OPTS}
+"

--- a/confluence/site/bin/setenv.sh
+++ b/confluence/site/bin/setenv.sh
@@ -15,7 +15,7 @@ CATALINA_OPTS="
  -XX:GCLogFileSize=2M
  -Djava.awt.headless=true
  -Datlassian.plugins.enable.wait=300
- -Xms4096m -Xmx8192m -XX:+UseG1GC
+ -Xms8192m -Xmx8192m -XX:+UseG1GC
  -XX:OnOutOfMemoryError=/srv/wiki/site/bin/oomkill
  ${CATALINA_OPTS}
 "

--- a/confluence/site/conf/server.xml
+++ b/confluence/site/conf/server.xml
@@ -1,22 +1,25 @@
 <Server port="8000" shutdown="SHUTDOWN" debug="0">
   <Service name="Tomcat-Standalone">
-    <Connector className="org.apache.coyote.tomcat4.CoyoteConnector" port="8080"
-               maxThreads="75" address="0.0.0.0"
-               enableLookups="false" redirectPort="8443" acceptCount="10" debug="0" connectionTimeout="20000"
-               scheme="@@PROXY_SCHEME@@" proxyName="@@PROXY_NAME@@" proxyPort="@@PROXY_PORT@@"
-               useURIValidationHack="false" URIEncoding="UTF-8"/>
+
+    <Connector port="8080" connectionTimeout="20000" redirectPort="8443"
+	    maxThreads="200" minSpareThreads="10" address="0.0.0.0"
+        scheme="@@PROXY_SCHEME@@" proxyName="@@PROXY_NAME@@" proxyPort="@@PROXY_PORT@@"
+        enableLookups="false" acceptCount="10" URIEncoding="UTF-8"
+        protocol="org.apache.coyote.http11.Http11NioProtocol" />
 
     <Engine name="Standalone" defaultHost="localhost" debug="0">
-      <Host name="localhost" debug="0" appBase="webapps" unpackWARs="true" autoDeploy="false">
-        <Context path="" docBase="/srv/wiki/base/confluence" debug="0" reloadable="false" useHttpOnly="true">
+      <Host name="localhost" appBase="webapps" unpackWARs="true" autoDeploy="false">
+        <Context path="" docBase="/srv/wiki/base/confluence" reloadable="false" useHttpOnly="true">
           <!-- Logger is deprecated in Tomcat 5.5. Logging configuration for Confluence is specified in confluence/WEB-INF/classes/log4j.properties -->
           <Manager pathname="" />
 
           <!-- to simplify going through wizard, expose a fully configured DataSource -->
           <Resource name="jdbc/wiki" auth="Container" type="javax.sql.DataSource"
-                    maxActive="30" maxIdle="30" maxWait="10000"
+                    maxTotal="15" maxIdle="7" maxWaitMillis="10000"
                     username="@@DB_USER@@" password="@@DB_PASSWORD@@" driverClassName="@@DB_JDBC_DRIVER@@"
-                        url="@@DB_JDBC_URL@@"/>
+                    defaultTransactionIsolation="READ_COMMITTED"
+                    validationQuery="Select 1"
+                    url="@@DB_JDBC_URL@@" />
         </Context>
 
         <!-- Tomcat manager is used to invalidate sessions. This helps fighting with ongoing spams -->

--- a/scripts/utf8_encoding.sql
+++ b/scripts/utf8_encoding.sql
@@ -1,0 +1,40 @@
+ALTER DATABASE wikidb CHARACTER SET utf8 COLLATE utf8_bin;
+
+set collation_server = 'utf8_bin';
+set collation_database = 'utf8_bin';
+set collation_connection = 'utf8_bin';
+
+/* Changing Table Collation: produce a series of ALTER TABLE statements that need to be apply*/
+SELECT CONCAT('ALTER TABLE ',  table_name, ' CHARACTER SET utf8 COLLATE utf8_bin;')
+FROM information_schema.TABLES AS T, information_schema.`COLLATION_CHARACTER_SET_APPLICABILITY` AS C
+WHERE C.collation_name = T.table_collation
+AND T.table_schema = 'wikidb'
+AND
+(
+    C.CHARACTER_SET_NAME != 'utf8'
+    OR
+    C.COLLATION_NAME != 'utf8_bin'
+);
+
+/* Changing Column Collation */
+SELECT CONCAT('ALTER TABLE `', table_name, '` MODIFY `', column_name, '` ', DATA_TYPE, '(', CHARACTER_MAXIMUM_LENGTH, ') CHARACTER SET UTF8 COLLATE utf8_bin', (CASE WHEN IS_NULLABLE = 'NO' THEN ' NOT NULL' ELSE '' END), ';')
+FROM information_schema.COLUMNS
+WHERE TABLE_SCHEMA = 'wikidb'
+AND DATA_TYPE = 'varchar'
+AND
+(
+    CHARACTER_SET_NAME != 'utf8'
+    OR
+    COLLATION_NAME != 'utf8_bin'
+);
+
+SELECT CONCAT('ALTER TABLE `', table_name, '` MODIFY `', column_name, '` ', DATA_TYPE, ' CHARACTER SET UTF8 COLLATE utf8_bin', (CASE WHEN IS_NULLABLE = 'NO' THEN ' NOT NULL' ELSE '' END), ';')
+FROM information_schema.COLUMNS
+WHERE TABLE_SCHEMA = 'wikidb'
+AND DATA_TYPE != 'varchar'
+AND
+(
+    CHARACTER_SET_NAME != 'utf8'
+    OR
+    COLLATION_NAME != 'utf8_bin'
+);


### PR DESCRIPTION
Upgrade from 5.0.3 to 5.9.14
- Usage of JDBC resource
- Upgrade from Openjdk 7 to Openjdk 8
- Upgrade to Tomcat 8
- Upgrade java heap size to 8Gb 
- Database must use utf8
- Database upgrade is very slow

! Database must be fully utf8 encoded before deploying confluence 5.9.14.

Generate mysql script to fix non utf8 table,columns
`sudo -Hu wiki mysql --max_allowed_packet=256M hudson_confluence < scripts/utf8_encoding.sql > /tmp/fix_utf8_encoding.sql`
Remove 'CONCAT entry from /tmp/fix_utf8_encoding.sql'
`sed -i '/CONCAT/d' /tmp/fix_utf8_encoding.sql`
Fix database for utf8
`sudo -Hu wiki mysql --max_allowed_packet=256M hudson_confluence < /tmp/fix_utf8_encoding.sql`
Remove /tmp/fix_utf8_encoding.sql
`rm /tmp/fix_utf8_encoding.sql`