### PR TITLE
[WIP] Bump confluence version to 5.10.8

### DIFF
--- a/confluence/Dockerfile
+++ b/confluence/Dockerfile
@@ -3,7 +3,7 @@
 FROM openjdk:8-jre
 MAINTAINER Jenkins Infra team <infra@lists.jenkins-ci.org>
 
-ENV CONFLUENCE_VERSION 5.9.14
+ENV CONFLUENCE_VERSION 5.10.8
 ENV MYSQL_DRIVER mysql-connector-java-5.1.42
 
 # The compartmentalized URL that JIRA is going to be referenced as.


### PR DESCRIPTION
Database migration took +- 20min to be applied (on a SSD)  