### PR TITLE
Fix [INFRA-1772]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ properties([
     pipelineTriggers([[$class:"SCMTrigger", scmpoll_spec:"H/15 * * * *"]]),
 ])
 
-node('docker') {
+node('docker&&linux') {
     def image
     stage('Build') {
         timestamps {

--- a/confluence/Dockerfile
+++ b/confluence/Dockerfile
@@ -1,6 +1,6 @@
 # Basics
 #
-FROM openjdk:8-jre
+FROM adoptopenjdk:8-jre-hotspot
 MAINTAINER Jenkins Infra team <infra@lists.jenkins-ci.org>
 
 ENV CONFLUENCE_VERSION 6.15.2


### PR DESCRIPTION
This switches the docker image to use AdoptOpenJDK Hotspot, which is listed as a supported runtime on the supported platforms page for Confluence (https://confluence.atlassian.com/doc/supported-platforms-207488198.html).

Also, update the node label to require docker&&linux for when we have Windows docker agents.